### PR TITLE
Add new hero cards and refactor card handling in game state

### DIFF
--- a/assets/data/hero_starting_cards.json
+++ b/assets/data/hero_starting_cards.json
@@ -3,5 +3,8 @@
   {"name": "Defend", "type": "Hero"},
   {"name": "Charge", "type": "Hero"},
   {"name": "Heal", "type": "Hero"},
-  {"name": "Block", "type": "Hero"}
+  {"name": "Block", "type": "Hero"},
+  {"name": "Dodge", "type": "Hero"},
+  {"name": "Counter", "type": "Hero"},
+  {"name": "Bash", "type": "Hero"}
 ]

--- a/lib/game/card_battler_game.dart
+++ b/lib/game/card_battler_game.dart
@@ -23,6 +23,7 @@ class CardBattlerGame extends FlameGame {
   @override
   Future<void> onLoad() async {
     List<ShopCardModel> shopCards = [];
+    List<CardModel> playerDeckCards = [];
 
     if (_testSize != null) {
       onGameResize(_testSize!);
@@ -31,15 +32,29 @@ class CardBattlerGame extends FlameGame {
           10,
           (index) => ShopCardModel(name: 'Test Card ${index + 1}', cost: 1),
         );
+
+      playerDeckCards = List.generate(
+          10,
+          (index) => CardModel(
+            name: 'Card ${index + 1}',
+            type: 'Player',
+            isFaceUp: false,
+          ),
+        );
     }
     else {
         shopCards = await loadCardsFromJson<ShopCardModel>(
           'assets/data/shop_cards.json',
           ShopCardModel.fromJson,
         );
+
+        playerDeckCards = await loadCardsFromJson<CardModel>(
+          'assets/data/hero_starting_cards.json',
+          CardModel.fromJson,
+        );
     }
 
-    _gameState = GameStateModel.newGame(shopCards);
+    _gameState = GameStateModel.newGame(shopCards, playerDeckCards);
     _loadGameComponents();
   }
 

--- a/lib/game/models/game_state_model.dart
+++ b/lib/game/models/game_state_model.dart
@@ -3,6 +3,7 @@ import 'package:card_battler/game/models/player/card_hand_model.dart';
 import 'package:card_battler/game/models/player/card_pile_model.dart';
 import 'package:card_battler/game/models/enemy/enemies_model.dart';
 import 'package:card_battler/game/models/player/player_model.dart';
+import 'package:card_battler/game/models/shared/card_model.dart';
 import 'package:card_battler/game/models/shared/health_model.dart';
 import 'package:card_battler/game/models/team/base_model.dart';
 import 'package:card_battler/game/models/team/player_stats_model.dart';
@@ -38,7 +39,7 @@ class GameStateModel {
   });
 
   /// Creates a new game with default starting values
-  factory GameStateModel.newGame(List<ShopCardModel> shopCards) {
+  factory GameStateModel.newGame(List<ShopCardModel> shopCards, List<CardModel> playerDeckCards) {
     return GameStateModel(
       player: PlayerModel(
         infoModel: InfoModel(
@@ -47,7 +48,7 @@ class GameStateModel {
           credits: ValueImageLabelModel(value: 50, label: 'Credits'),
         ),
         handModel: CardHandModel(),
-        deckModel: CardPileModel(numberOfCards: 20),
+        deckModel: CardPileModel(cards: playerDeckCards),
         discardModel: CardPileModel.empty(),
       ),
       enemies: EnemiesModel(

--- a/lib/game/models/player/card_pile_model.dart
+++ b/lib/game/models/player/card_pile_model.dart
@@ -4,15 +4,8 @@ import 'package:card_battler/game/models/shared/reactive_model.dart';
 class CardPileModel with ReactiveModel<CardPileModel> {
   final List<CardModel> _cards;
 
-  CardPileModel({int numberOfCards = 0, List<CardModel>? cards})
-      : _cards = cards ?? List.generate(
-          numberOfCards,
-          (index) => CardModel(
-            name: 'Card ${index + 1}',
-            type: 'Player',
-            isFaceUp: false,
-          ),
-        );
+  CardPileModel({List<CardModel> cards = const []})
+      : _cards = cards;
 
   CardPileModel.empty() : _cards = [];
 

--- a/test/game/components/player/card_deck_test.dart
+++ b/test/game/components/player/card_deck_test.dart
@@ -1,4 +1,5 @@
 import 'package:card_battler/game/models/player/card_pile_model.dart';
+import 'package:card_battler/game/models/shared/card_model.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:card_battler/game/components/player/card_deck.dart';
 import 'package:card_battler/game/components/shared/card.dart';
@@ -6,11 +7,18 @@ import 'package:flame_test/flame_test.dart';
 import 'package:flame/components.dart';
 import 'package:flame/events.dart';
 
+List<CardModel> _generateCards(int count) {
+  return List.generate(count, (index) => CardModel(
+    name: 'Card $index',
+    type: 'test',
+  ));
+}
+
 void main() {
   group('CardDeck', () {
     group('inheritance from CardPile', () {
       testWithFlameGame('inherits all CardPile functionality with cards', (game) async {
-        final deck = CardDeck(CardPileModel(numberOfCards: 5))
+        final deck = CardDeck(CardPileModel(cards: _generateCards(5)))
           ..size = Vector2(100, 150);
 
         await game.ensureAdd(deck);
@@ -40,7 +48,7 @@ void main() {
       });
 
       testWithFlameGame('debug mode enabled like CardPile', (game) async {
-        final deck = CardDeck(CardPileModel(numberOfCards: 3));
+        final deck = CardDeck(CardPileModel(cards: _generateCards(3)));
         
         expect(deck.debugMode, isTrue);
       });
@@ -50,7 +58,7 @@ void main() {
       testWithFlameGame('calls onTap callback when tapped', (game) async {
         bool tapped = false;
         final deck = CardDeck(
-          CardPileModel(numberOfCards: 3),
+          CardPileModel(cards: _generateCards(3)),
           onTap: () => tapped = true,
         )..size = Vector2(100, 150);
 
@@ -63,7 +71,7 @@ void main() {
       });
 
       testWithFlameGame('does not throw when no onTap callback provided', (game) async {
-        final deck = CardDeck(CardPileModel(numberOfCards: 3))
+        final deck = CardDeck(CardPileModel(cards: _generateCards(3)))
           ..size = Vector2(100, 150);
 
         await game.ensureAdd(deck);
@@ -74,7 +82,7 @@ void main() {
       testWithFlameGame('onTap callback can be called multiple times', (game) async {
         int tapCount = 0;
         final deck = CardDeck(
-          CardPileModel(numberOfCards: 3),
+          CardPileModel(cards: _generateCards(3)),
           onTap: () => tapCount++,
         )..size = Vector2(100, 150);
 
@@ -94,7 +102,7 @@ void main() {
         }
 
         final deck = CardDeck(
-          CardPileModel(numberOfCards: 3),
+          CardPileModel(cards: _generateCards(3)),
           onTap: testCallback,
         )..size = Vector2(100, 150);
 
@@ -108,7 +116,7 @@ void main() {
 
     group('constructor', () {
       test('accepts CardPileModel and optional onTap callback', () {
-        final model = CardPileModel(numberOfCards: 5);
+        final model = CardPileModel(cards: _generateCards(5));
         void callback() {}
 
         final deckWithCallback = CardDeck(model, onTap: callback);
@@ -141,7 +149,7 @@ void main() {
         testWithFlameGame('deck size ${testCase['size']} with ${testCase['cards']} cards handles taps correctly', (game) async {
           bool tapped = false;
           final deck = CardDeck(
-            CardPileModel(numberOfCards: testCase['cards'] as int),
+            CardPileModel(cards: _generateCards(testCase['cards'] as int)),
             onTap: () => tapped = true,
           )..size = testCase['size'] as Vector2;
 
@@ -156,7 +164,7 @@ void main() {
 
     group('TapCallbacks mixin integration', () {
       testWithFlameGame('implements TapCallbacks correctly', (game) async {
-        final deck = CardDeck(CardPileModel(numberOfCards: 3));
+        final deck = CardDeck(CardPileModel(cards: _generateCards(3)));
         
         expect(deck, isA<TapCallbacks>());
         
@@ -167,7 +175,7 @@ void main() {
       });
 
       testWithFlameGame('tap callback can be null without issues', (game) async {
-        final deck = CardDeck(CardPileModel(numberOfCards: 3));
+        final deck = CardDeck(CardPileModel(cards: _generateCards(3)));
         
         await game.ensureAdd(deck);
         

--- a/test/game/components/player/card_pile_test.dart
+++ b/test/game/components/player/card_pile_test.dart
@@ -6,6 +6,13 @@ import 'package:card_battler/game/components/shared/card.dart';
 import 'package:flame_test/flame_test.dart';
 import 'package:flame/components.dart';
 
+List<CardModel> _generateCards(int count) {
+  return List.generate(count, (index) => CardModel(
+    name: 'Card $index',
+    type: 'test',
+  ));
+}
+
 void main() {
   group('CardPile', () {
     group('with cards', () {
@@ -23,7 +30,7 @@ void main() {
       ];
       for (final testCase in testCases) {
         testWithFlameGame('Pile child size and position for pile size ${testCase['deckSize']}', (game) async {
-          final pile = CardPile(CardPileModel(numberOfCards: 3))..size = testCase['deckSize'] as Vector2;
+          final pile = CardPile(CardPileModel(cards: _generateCards(3)))..size = testCase['deckSize'] as Vector2;
 
           await game.ensureAdd(pile);
 
@@ -95,7 +102,7 @@ void main() {
         ];
 
         for (final testCase in testCases) {
-          final pile = CardPile(CardPileModel(numberOfCards: testCase['numberOfCards'] as int))
+          final pile = CardPile(CardPileModel(cards: _generateCards(testCase['numberOfCards'] as int)))
             ..size = Vector2(100, 150);
 
           await game.ensureAdd(pile);
@@ -132,7 +139,7 @@ void main() {
         ];
 
         for (final testCase in testCases) {
-          final pile = CardPile(CardPileModel(numberOfCards: 7))
+          final pile = CardPile(CardPileModel(cards: _generateCards(7)))
             ..size = testCase['size'] as Vector2;
 
           await game.ensureAdd(pile);
@@ -173,7 +180,7 @@ void main() {
       });
 
       testWithFlameGame('updates display automatically when cards are drawn from model', (game) async {
-        final model = CardPileModel(numberOfCards: 5);
+        final model = CardPileModel(cards: _generateCards(5));
         final pile = CardPile(model)..size = Vector2(100, 150);
 
         await game.ensureAdd(pile);
@@ -198,7 +205,7 @@ void main() {
       });
 
       testWithFlameGame('updates count automatically when individual cards are drawn', (game) async {
-        final model = CardPileModel(numberOfCards: 3);
+        final model = CardPileModel(cards: _generateCards(3));
         final pile = CardPile(model)..size = Vector2(100, 150);
 
         await game.ensureAdd(pile);
@@ -221,7 +228,7 @@ void main() {
       });
 
       testWithFlameGame('cleans up stream subscription on component removal', (game) async {
-        final model = CardPileModel(numberOfCards: 2);
+        final model = CardPileModel(cards: _generateCards(2));
         final pile = CardPile(model)..size = Vector2(100, 150);
 
         await game.ensureAdd(pile);

--- a/test/game/components/player/player_test.dart
+++ b/test/game/components/player/player_test.dart
@@ -10,8 +10,17 @@ import 'package:card_battler/game/models/player/card_hand_model.dart';
 import 'package:card_battler/game/models/player/card_pile_model.dart';
 import 'package:card_battler/game/models/player/player_model.dart';
 import 'package:card_battler/game/models/shared/value_image_label_model.dart';
+import 'package:card_battler/game/models/shared/card_model.dart';
 import 'package:flame_test/flame_test.dart';
 import 'package:flame/components.dart';
+
+List<CardModel> _generateCards(int count) {
+  return List.generate(count, (index) => CardModel(
+    name: 'Card $index',
+    type: 'test',
+    isFaceUp: false,
+  ));
+}
 
 void main() {
   group('Player', () {
@@ -22,7 +31,7 @@ void main() {
         credits: ValueImageLabelModel(value: 25, label: 'Credits'),
       );
       final handModel = CardHandModel();
-      final deckModel = CardPileModel(numberOfCards: 20);
+      final deckModel = CardPileModel(cards: _generateCards(20));
       final discardModel = CardPileModel.empty();
       
       final playerModel = PlayerModel(

--- a/test/game/models/game_state_model_test.dart
+++ b/test/game/models/game_state_model_test.dart
@@ -1,6 +1,15 @@
 import 'package:flutter_test/flutter_test.dart';
 import 'package:card_battler/game/models/game_state_model.dart';
 import 'package:card_battler/game/models/shop/shop_card_model.dart';
+import 'package:card_battler/game/models/shared/card_model.dart';
+
+List<CardModel> _generatePlayerDeckCards() {
+  return List.generate(20, (index) => CardModel(
+    name: 'Player Card ${index + 1}',
+    type: 'Player',
+    isFaceUp: false,
+  ));
+}
 
 void main() {
   TestWidgetsFlutterBinding.ensureInitialized();
@@ -9,7 +18,8 @@ void main() {
       test('creates new game with default state', () {
         // Create empty shop cards list for new game
         final shopCards = <ShopCardModel>[];
-        final gameState = GameStateModel.newGame(shopCards);
+        final playerDeckCards = _generatePlayerDeckCards();
+        final gameState = GameStateModel.newGame(shopCards, playerDeckCards);
         
         expect(gameState, isNotNull);
         expect(gameState.player, isNotNull);
@@ -23,7 +33,8 @@ void main() {
       test('GameStateModel contains all required components', () {
         // Create empty shop cards list for new game
         final shopCards = <ShopCardModel>[];
-        final gameState = GameStateModel.newGame(shopCards);
+        final playerDeckCards = _generatePlayerDeckCards();
+        final gameState = GameStateModel.newGame(shopCards, playerDeckCards);
         
         expect(gameState.player, isNotNull);
         expect(gameState.enemies, isNotNull);
@@ -36,7 +47,8 @@ void main() {
       test('new game state is in consistent initial state', () {
         // Create empty shop cards list for new game
         final shopCards = <ShopCardModel>[];
-        final gameState = GameStateModel.newGame(shopCards);
+        final playerDeckCards = _generatePlayerDeckCards();
+        final gameState = GameStateModel.newGame(shopCards, playerDeckCards);
         
         // All component models should be initialized
         expect(gameState.player, isNotNull);

--- a/test/game/models/player/card_pile_model_test.dart
+++ b/test/game/models/player/card_pile_model_test.dart
@@ -2,6 +2,14 @@ import 'package:flutter_test/flutter_test.dart';
 import 'package:card_battler/game/models/player/card_pile_model.dart';
 import 'package:card_battler/game/models/shared/card_model.dart';
 
+List<CardModel> _generateCards(int count) {
+  return List.generate(count, (index) => CardModel(
+    name: 'Card ${index + 1}',
+    type: 'test',
+    isFaceUp: false,
+  ));
+}
+
 void main() {
   group('CardPileModel', () {
     group('constructor and initialization', () {
@@ -21,7 +29,8 @@ void main() {
         ];
 
         for (final testCase in testCases) {
-          final model = CardPileModel(numberOfCards: testCase['numberOfCards'] as int);
+          final cardCount = testCase['numberOfCards'] as int;
+          final model = CardPileModel(cards: _generateCards(cardCount));
           
           expect(model.allCards.length, equals(testCase['expectedLength']));
           expect(model.hasNoCards, equals(testCase['expectedLength'] == 0));
@@ -46,11 +55,11 @@ void main() {
         expect(model.allCards, equals(cards));
       });
 
-      test('provided cards list takes precedence over numberOfCards', () {
+      test('creates with provided cards list', () {
         final cards = [
           CardModel(name: 'Override Card', type: 'Player'),
         ];
-        final model = CardPileModel(numberOfCards: 5, cards: cards);
+        final model = CardPileModel(cards: cards);
         
         expect(model.allCards.length, equals(1));
         expect(model.allCards.first.name, equals('Override Card'));
@@ -74,7 +83,7 @@ void main() {
 
     group('properties', () {
       test('allCards returns unmodifiable list', () {
-        final model = CardPileModel(numberOfCards: 2);
+        final model = CardPileModel(cards: _generateCards(2));
         final cards = model.allCards;
         
         expect(() => cards.add(CardModel(name: 'Test', type: 'Player')), 
@@ -82,7 +91,7 @@ void main() {
       });
 
       test('hasNoCards returns correct value for non-empty pile', () {
-        final model = CardPileModel(numberOfCards: 3);
+        final model = CardPileModel(cards: _generateCards(3));
         expect(model.hasNoCards, isFalse);
       });
 
@@ -96,8 +105,8 @@ void main() {
         expect(model.hasNoCards, isTrue);
       });
 
-      test('hasNoCards returns correct value for pile with numberOfCards = 0', () {
-        final model = CardPileModel(numberOfCards: 0);
+      test('hasNoCards returns correct value for pile with empty cards list', () {
+        final model = CardPileModel(cards: _generateCards(0));
         expect(model.hasNoCards, isTrue);
       });
     });
@@ -105,7 +114,7 @@ void main() {
     group('card drawing methods', () {
       group('drawCards', () {
         test('draws correct number of cards from pile', () {
-          final model = CardPileModel(numberOfCards: 10);
+          final model = CardPileModel(cards: _generateCards(10));
           final originalCount = model.allCards.length;
           
           final drawnCards = model.drawCards(3);
@@ -130,7 +139,7 @@ void main() {
         });
 
         test('returns empty list when drawing zero cards', () {
-          final model = CardPileModel(numberOfCards: 5);
+          final model = CardPileModel(cards: _generateCards(5));
           
           final drawnCards = model.drawCards(0);
           
@@ -139,7 +148,7 @@ void main() {
         });
 
         test('returns empty list when drawing negative number of cards', () {
-          final model = CardPileModel(numberOfCards: 5);
+          final model = CardPileModel(cards: _generateCards(5));
           
           final drawnCards = model.drawCards(-1);
           
@@ -148,7 +157,7 @@ void main() {
         });
 
         test('draws all available cards when requesting more than available', () {
-          final model = CardPileModel(numberOfCards: 3);
+          final model = CardPileModel(cards: _generateCards(3));
           
           final drawnCards = model.drawCards(5);
           
@@ -166,7 +175,7 @@ void main() {
         });
 
         test('multiple draws work correctly', () {
-          final model = CardPileModel(numberOfCards: 10);
+          final model = CardPileModel(cards: _generateCards(10));
           
           final firstDraw = model.drawCards(3);
           final secondDraw = model.drawCards(2);
@@ -179,7 +188,7 @@ void main() {
 
       group('drawCard', () {
         test('draws single card from pile', () {
-          final model = CardPileModel(numberOfCards: 5);
+          final model = CardPileModel(cards: _generateCards(5));
           final originalCount = model.allCards.length;
           
           final drawnCard = model.drawCard();
@@ -210,7 +219,7 @@ void main() {
         });
 
         test('multiple single draws work correctly', () {
-          final model = CardPileModel(numberOfCards: 3);
+          final model = CardPileModel(cards: _generateCards(3));
           
           final firstCard = model.drawCard();
           final secondCard = model.drawCard();

--- a/test/game/models/player/player_model_test.dart
+++ b/test/game/models/player/player_model_test.dart
@@ -4,6 +4,15 @@ import 'package:card_battler/game/models/player/info_model.dart';
 import 'package:card_battler/game/models/player/card_hand_model.dart';
 import 'package:card_battler/game/models/player/card_pile_model.dart';
 import 'package:card_battler/game/models/shared/value_image_label_model.dart';
+import 'package:card_battler/game/models/shared/card_model.dart';
+
+List<CardModel> _generateCards(int count) {
+  return List.generate(count, (index) => CardModel(
+    name: 'Card ${index + 1}',
+    type: 'test',
+    isFaceUp: false,
+  ));
+}
 
 void main() {
   group('PlayerModel', () {
@@ -19,7 +28,7 @@ void main() {
         credits: ValueImageLabelModel(value: 25, label: 'Credits'),
       );
       testHandModel = CardHandModel();
-      testDeckModel = CardPileModel(numberOfCards: 20);
+      testDeckModel = CardPileModel(cards: _generateCards(20));
       testDiscardModel = CardPileModel.empty();
     });
 


### PR DESCRIPTION
- Added "Dodge", "Counter", and "Bash" hero cards to the starting deck.
- Updated CardBattlerGame to initialize player deck cards from JSON.
- Refactored GameStateModel to accept player deck cards during new game creation.
- Modified CardPileModel to use a list of cards instead of a card count.
- Updated tests for CardDeck, CardPileModel, and GameStateModel to reflect changes in card handling.